### PR TITLE
split equipment in weapons and artifacts

### DIFF
--- a/carddata/cards.json
+++ b/carddata/cards.json
@@ -2,11 +2,10 @@
     {
         "id": 312701,
         "name": "Laurel Coronet",
-        "type": "equipment",
+        "type": "artifact",
         "cost": {
             "amount": 2
         },
-        "slot": "artifact",
         "effects": [
             {
                 "trigger": {
@@ -25,11 +24,10 @@
     {
         "id": 312601,
         "name": "Mask of Solitude Basalt",
-        "type": "equipment",
+        "type": "artifact",
         "cost": {
             "amount": 2
         },
-        "slot": "artifact",
         "effects": [
             {
                 "trigger": {
@@ -48,11 +46,10 @@
     {
         "id": 312501,
         "name": "Viridescent Venerer's Diadem",
-        "type": "equipment",
+        "type": "artifact",
         "cost": {
             "amount": 2
         },
-        "slot": "artifact",
         "effects": [
             {
                 "trigger": {
@@ -71,11 +68,10 @@
     {
         "id": 312401,
         "name": "Thunder Summoner's Crown",
-        "type": "equipment",
+        "type": "artifact",
         "cost": {
             "amount": 2
         },
-        "slot": "artifact",
         "effects": [
             {
                 "trigger": {
@@ -94,11 +90,10 @@
     {
         "id": 312301,
         "name": "Witch's Scorching Hat",
-        "type": "equipment",
+        "type": "artifact",
         "cost": {
             "amount": 2
         },
-        "slot": "artifact",
         "effects": [
             {
                 "trigger": {
@@ -117,11 +112,10 @@
     {
         "id": 312201,
         "name": "Wine-Stained Tricorne",
-        "type": "equipment",
+        "type": "artifact",
         "cost": {
             "amount": 2
         },
-        "slot": "artifact",
         "effects": [
             {
                 "trigger": {
@@ -140,11 +134,10 @@
     {
         "id": 312101,
         "name": "Broken Rime's Echo",
-        "type": "equipment",
+        "type": "artifact",
         "cost": {
             "amount": 2
         },
-        "slot": "artifact",
         "effects": [
             {
                 "trigger": {
@@ -163,11 +156,10 @@
     {
         "id": 311101,
         "name": "Magic Guide",
-        "type": "equipment",
+        "type": "weapon",
         "cost": {
             "amount": 2
         },
-        "slot": "weapon",
         "weapon": "Catalyst",
         "effects": [
             {
@@ -182,11 +174,10 @@
     {
         "id": 311501,
         "name": "Traveler's Handy Sword",
-        "type": "equipment",
+        "type": "weapon",
         "cost": {
             "amount": 2
         },
-        "slot": "weapon",
         "weapon": "Sword",
         "effects": [
             {
@@ -201,11 +192,10 @@
     {
         "id": 311401,
         "name": "White Tassel",
-        "type": "equipment",
+        "type": "weapon",
         "cost": {
             "amount": 2
         },
-        "slot": "weapon",
         "weapon": "Polearm",
         "effects": [
             {
@@ -220,11 +210,10 @@
     {
         "id": 311301,
         "name": "White Iron Greatsword",
-        "type": "equipment",
+        "type": "weapon",
         "cost": {
             "amount": 2
         },
-        "slot": "weapon",
         "weapon": "Claymore",
         "effects": [
             {
@@ -239,11 +228,10 @@
     {
         "id": 311201,
         "name": "Raven Bow",
-        "type": "equipment",
+        "type": "weapon",
         "cost": {
             "amount": 2
         },
-        "slot": "weapon",
         "weapon": "Bow",
         "effects": [
             {

--- a/invokator/interface/character.py
+++ b/invokator/interface/character.py
@@ -30,7 +30,8 @@ class Character(models.Character):
     infused_element: models.Element | None = None
 
     status: list[CharacterStatus] = []
-    equipment: list[models.EquipmentCard] = []
+    equipped_weapon: models.WeaponCard | None = None
+    equipped_artifact: models.ArtifactCard | None = None
 
     def __init__(self, **kwargs: typing.Any) -> None:
         super().__init__(**kwargs)

--- a/invokator/interface/hand.py
+++ b/invokator/interface/hand.py
@@ -7,7 +7,8 @@ CARD_TYPE_ORDER = (
     models.CardType.CHARACTER,
     models.CardType.EVENT,
     models.CardType.SUPPORT,
-    models.CardType.EQUIPMENT,
+    models.CardType.WEAPON,
+    models.CardType.ARTIFACT,
 )
 
 

--- a/invokator/models/card.py
+++ b/invokator/models/card.py
@@ -5,7 +5,7 @@ import pydantic
 from typing_extensions import Self
 
 from .effect import DiceCost, Effect
-from .enums import CardType, Element, EquipmentType, WeaponType
+from .enums import CardType, Element, WeaponType
 
 
 class Card(pydantic.BaseModel):
@@ -22,14 +22,21 @@ class Card(pydantic.BaseModel):
     cost: DiceCost
 
 
-class EquipmentCard(Card):
+class WeaponCard(Card):
     """TCG equipment card data."""
 
-    type: CardType = CardType.EQUIPMENT
+    type: CardType = CardType.WEAPON
 
-    slot: EquipmentType
+    weapon: WeaponType
+
+    effects: list[Effect]
+
+
+class ArtifactCard(Card):
+
+    type: CardType = CardType.ARTIFACT
+
     element: Element | None = None
-    weapon: WeaponType | None = None
 
     effects: list[Effect]
 

--- a/invokator/models/card.py
+++ b/invokator/models/card.py
@@ -23,7 +23,7 @@ class Card(pydantic.BaseModel):
 
 
 class WeaponCard(Card):
-    """TCG equipment card data."""
+    """TCG weapon card data."""
 
     type: CardType = CardType.WEAPON
 
@@ -33,6 +33,7 @@ class WeaponCard(Card):
 
 
 class ArtifactCard(Card):
+    """TCG artifact card data."""
 
     type: CardType = CardType.ARTIFACT
 

--- a/invokator/models/enums.py
+++ b/invokator/models/enums.py
@@ -69,8 +69,10 @@ class CardType(str, enum.Enum):
     """Support card."""
     FOOD = "food"
     """Food card."""
-    EQUIPMENT = "equipment"
-    """Equipment card."""
+    WEAPON = "weapon"
+    """Weapon card."""
+    ARTIFACT = "artifact"
+    """Artifact card."""
     CHARACTER = "character"
     """Character card."""
 


### PR DESCRIPTION
This PR splits the existing `EquipmentCard` into separate `WeaponCard` and `ArtifactCard` classes. The old equipment card class came with the issue that either the `element` field was dead for a weapon card, or the `weapon` field was dead for an artifact card. To amend this, the `slot` field in equipment cards' json data was removed and the value is now used for their `type` field instead.

Note that the `EquipmentType` enum is still present, as it is still used in `invokator.models.effect.ShiftEffect`.